### PR TITLE
config: bring up dd_agent and use new hyperlane image

### DIFF
--- a/mev-commit-cli.sh
+++ b/mev-commit-cli.sh
@@ -238,7 +238,9 @@ start_bridge(){
     local rpc_url=${2:-$DEFAULT_RPC_URL}
     local chain_id=${3:-17864}  # Default chain ID
     local private_key=${4:-"0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"}
-    AGENT_BASE_IMAGE=shaspitz/hyperlane-agent:sha-e277ebfd8 \
+    # Try most recent agent release: https://github.com/hyperlane-xyz/hyperlane-monorepo/releases/tag/agents-2023-12-14
+    # Eventually build from our fork?
+    AGENT_BASE_IMAGE=gcr.io/abacus-labs-dev/hyperlane-agent:a888cf7-20231214-180118 \
         PUBLIC_SETTLEMENT_RPC_URL="$public_rpc_url" \
         SETTLEMENT_RPC_URL="$rpc_url" \
         docker compose -f "$BRIDGE_PATH/hyperlane/docker-compose.yml" --profile bridge --profile dd_agent up -d --build

--- a/mev-commit-cli.sh
+++ b/mev-commit-cli.sh
@@ -266,7 +266,7 @@ start_bridge(){
 }
 
 stop_bridge(){
-    AGENT_BASE_IMAGE=gcr.io/abacus-labs-dev/hyperlane-agent@sha256:854f92966eac6b49e5132e152cc58168ecdddc76c2d390e657b81bdaf1396af0 PUBLIC_SETTLEMENT_RPC_URL="$public_rpc_url" SETTLEMENT_RPC_URL="$rpc_url" docker compose -f "$BRIDGE_PATH/hyperlane/docker-compose.yml" --profile bridge down
+    AGENT_BASE_IMAGE=gcr.io/abacus-labs-dev/hyperlane-agent@sha256:854f92966eac6b49e5132e152cc58168ecdddc76c2d390e657b81bdaf1396af0 PUBLIC_SETTLEMENT_RPC_URL="$public_rpc_url" SETTLEMENT_RPC_URL="$rpc_url" docker compose -f "$BRIDGE_PATH/hyperlane/docker-compose.yml" --profile bridge --profile dd_agent down
 }
 
 clean() {

--- a/mev-commit-cli.sh
+++ b/mev-commit-cli.sh
@@ -238,10 +238,10 @@ start_bridge(){
     local rpc_url=${2:-$DEFAULT_RPC_URL}
     local chain_id=${3:-17864}  # Default chain ID
     local private_key=${4:-"0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"}
-    AGENT_BASE_IMAGE=gcr.io/abacus-labs-dev/hyperlane-agent@sha256:854f92966eac6b49e5132e152cc58168ecdddc76c2d390e657b81bdaf1396af0 \
+    AGENT_BASE_IMAGE=shaspitz/hyperlane-agent:sha-e277ebfd8 \
         PUBLIC_SETTLEMENT_RPC_URL="$public_rpc_url" \
         SETTLEMENT_RPC_URL="$rpc_url" \
-        docker compose -f "$BRIDGE_PATH/hyperlane/docker-compose.yml" --profile bridge up -d --build
+        docker compose -f "$BRIDGE_PATH/hyperlane/docker-compose.yml" --profile bridge --profile dd_agent up -d --build
 
     # Run Alpine container which:
     # 1. Install jq


### PR DESCRIPTION
- brings up dd agent profile from https://github.com/primevprotocol/mev-commit-bridge/commit/914e2762f718ca947d3b7d73ffb7c23e0e7cb010
- uses newly built hyperlane agent image [here](https://hub.docker.com/layers/shaspitz/hyperlane-agent/sha-e277ebfd8/images/sha256-43cd774ddc71e488a00f1b15745a21bbb83f4908a29b00b189a68e18a466ee44?context=repo) which allows for trace level logs