### PR TITLE
Updates bootnode url

### DIFF
--- a/mev-commit-cli.sh
+++ b/mev-commit-cli.sh
@@ -2,7 +2,7 @@
 
 # Default RPC URL and Paths
 L1_RPC_BASE_URL=https://sepolia.infura.io/v3
-DEFAULT_RPC_URL="http://sl-bootnode:8545"
+DEFAULT_RPC_URL="http://geth-poa-sl-bootnode-1:8545"
 PRIMEV_DIR="$HOME/.primev"
 
 GETH_REPO_NAME="mev-commit-geth"


### PR DESCRIPTION
Here's a dump of the new network for our stack:
```
[
    {
        "Name": "primev_net",
        ...
        "Containers": {
            "5c5de43473d319e7ed19df573dd08cee6b7db2d575fcc11de736921b57e5384c": {
                "Name": "geth-poa-sl-node3-1",
                "EndpointID": "9655afcc8830d9cc156785fda4c2c236851301c6f007e35f96d11f4ae268a797",
                "MacAddress": "02:42:ac:1d:00:65",
                "IPv4Address": "172.29.0.101/16",
                "IPv6Address": ""
            },
            "8b7cb7c83b5ffbeb0f9427784c3f4de80777cf570dc7bcc1cd265073b3d1ab80": {
                "Name": "geth-poa-sl-bootnode-1",
                "EndpointID": "8801044e1fc6c26608f4c2428600271b7001e179ef39614bc2160e70d7363f62",
                "MacAddress": "02:42:ac:1d:00:62",
                "IPv4Address": "172.29.0.98/16",
                "IPv6Address": ""
            },
            "d2bcc5d1461e07f7f7226962b0038a00816bdd534f105b9fd20a62474bc07e88": {
                "Name": "geth-poa-sl-node2-1",
                "EndpointID": "22a4bcc0a365530e655d40c01d3c4f9782f456e97aa0195d2f481fee958dafb0",
                "MacAddress": "02:42:ac:1d:00:64",
                "IPv4Address": "172.29.0.100/16",
                "IPv6Address": ""
            },
            "fcbe2df3216642a4ebf44aa7a1a5b6fc23caf39132b8e6b2efc76ae51113293c": {
                "Name": "geth-poa-sl-node1-1",
                "EndpointID": "c868996e0fb5dafd2bd5bfc0aaa1c69c7e0c3c9f8e846fe101f51f51589061fe",
                "MacAddress": "02:42:ac:1d:00:63",
                "IPv4Address": "172.29.0.99/16",
                "IPv6Address": ""
            }
        },
        "Options": {},
        "Labels": {}
    }
]
```