### PR TITLE
fix: fee suggestion

### DIFF
--- a/pkg/evmclient/evm.go
+++ b/pkg/evmclient/evm.go
@@ -26,6 +26,7 @@ type EVM interface {
 	NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
 	// SuggestGasPrice retrieves the currently suggested gas price to allow a timely
 	// execution of a transaction.
+	// Note after eip 1559 this returns suggested priority fee per gas + suggested base fee per gas.
 	SuggestGasPrice(ctx context.Context) (*big.Int, error)
 	// SuggestGasTipCap retrieves the currently suggested 1559 priority fee to allow
 	// a timely execution of a transaction.

--- a/pkg/evmclient/evmclient.go
+++ b/pkg/evmclient/evmclient.go
@@ -103,11 +103,13 @@ func (c *EvmClient) suggestMaxFeeAndTipCap(
 	ctx context.Context,
 	gasPrice *big.Int,
 ) (*big.Int, *big.Int, error) {
+	// Returns priority fee per gas
 	gasTipCap, err := c.ethClient.SuggestGasTipCap(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to suggest gas tip cap: %w", err)
 	}
 
+	// Returns priority fee per gas + base fee per gas
 	if gasPrice == nil {
 		gasPrice, err = c.ethClient.SuggestGasPrice(ctx)
 		if err != nil {
@@ -115,7 +117,7 @@ func (c *EvmClient) suggestMaxFeeAndTipCap(
 		}
 	}
 
-	gasFeeCap := new(big.Int).Add(gasTipCap, gasPrice)
+	gasFeeCap := gasPrice
 
 	return gasFeeCap, gasTipCap, nil
 }

--- a/pkg/evmclient/evmclient.go
+++ b/pkg/evmclient/evmclient.go
@@ -117,9 +117,7 @@ func (c *EvmClient) suggestMaxFeeAndTipCap(
 		}
 	}
 
-	gasFeeCap := gasPrice
-
-	return gasFeeCap, gasTipCap, nil
+	return gasPrice, gasTipCap, nil
 }
 
 func (c *EvmClient) newTx(ctx context.Context, req *TxRequest, nonce uint64) (*types.Transaction, error) {

--- a/pkg/evmclient/evmclient_test.go
+++ b/pkg/evmclient/evmclient_test.go
@@ -60,7 +60,7 @@ func TestSendCall(t *testing.T) {
 		),
 		mockevm.WithSuggestGasPriceFunc(
 			func(ctx context.Context) (*big.Int, error) {
-				return big.NewInt(1000000000), nil
+				return big.NewInt(2000000000), nil
 			},
 		),
 		mockevm.WithSuggestGasTipCapFunc(
@@ -71,7 +71,7 @@ func TestSendCall(t *testing.T) {
 		mockevm.WithSendTransactionFunc(
 			func(ctx context.Context, tx *types.Transaction) error {
 				if tx.GasFeeCap().Cmp(big.NewInt(2000000000)) != 0 {
-					return fmt.Errorf("expected gas price to be 1000000000, got %v", tx.GasPrice())
+					return fmt.Errorf("expected gas price to be 2000000000, got %v", tx.GasPrice())
 				}
 				if tx.GasTipCap().Cmp(big.NewInt(1000000000)) != 0 {
 					return fmt.Errorf("expected gas tip cap to be 1000000000, got %v", tx.GasTipCap())
@@ -229,7 +229,7 @@ func TestCancel(t *testing.T) {
 					return nil
 				}
 				if tx.GasFeeCap().Cmp(big.NewInt(2000000000)) <= 0 {
-					return fmt.Errorf("expected gas price to be 1000000000, got %v", tx.GasFeeCap())
+					return fmt.Errorf("expected gas price to be 2000000000, got %v", tx.GasFeeCap())
 				}
 				if tx.GasTipCap().Cmp(big.NewInt(1000000000)) <= 0 {
 					return fmt.Errorf("expected gas tip cap to be 1000000000, got %v", tx.GasTipCap())


### PR DESCRIPTION
`eth_gasPrice` rpc method returns a suggested priority fee per gas + base fee per gas. Our tx param logic previously assumed the rpc was returning only base fee per gas 