### PR TITLE
clean up main.go and separation in keysigner package

### DIFF
--- a/pkg/keysigner/keysigner.go
+++ b/pkg/keysigner/keysigner.go
@@ -3,14 +3,9 @@ package keysigner
 import (
 	"crypto/ecdsa"
 	"math/big"
-	"os"
-	"runtime"
 
-	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 type KeySigner interface {
@@ -19,93 +14,4 @@ type KeySigner interface {
 	GetAddress() common.Address
 	GetPrivateKey() (*ecdsa.PrivateKey, error)
 	ZeroPrivateKey(key *ecdsa.PrivateKey)
-}
-
-type privateKeySigner struct {
-	privKey *ecdsa.PrivateKey
-}
-
-func NewPrivateKeySigner(privKey *ecdsa.PrivateKey) *privateKeySigner {
-	return &privateKeySigner{
-		privKey: privKey,
-	}
-}
-
-func (pks *privateKeySigner) SignHash(hash []byte) ([]byte, error) {
-	return crypto.Sign(hash, pks.privKey)
-}
-
-func (pks *privateKeySigner) SignTx(tx *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
-	return types.SignTx(tx, types.NewLondonSigner(chainID), pks.privKey)
-}
-
-func (pks *privateKeySigner) GetAddress() common.Address {
-	return crypto.PubkeyToAddress(pks.privKey.PublicKey)
-}
-
-func (pks *privateKeySigner) GetPrivateKey() (*ecdsa.PrivateKey, error) {
-	return pks.privKey, nil
-}
-
-// ZeroPrivateKey does nothing because the private key for PKS persists in memory
-// and should not be deleted.
-func (pks *privateKeySigner) ZeroPrivateKey(key *ecdsa.PrivateKey) {}
-
-type keystoreSigner struct {
-	keystore *keystore.KeyStore
-	password string
-	account  accounts.Account
-}
-
-func NewKeystoreSigner(keystore *keystore.KeyStore, password string, account accounts.Account) *keystoreSigner {
-	return &keystoreSigner{
-		keystore: keystore,
-		password: password,
-		account:  account,
-	}
-}
-
-func (kss *keystoreSigner) SignHash(hash []byte) ([]byte, error) {
-	return kss.keystore.SignHashWithPassphrase(kss.account, kss.password, hash)
-}
-
-func (kss *keystoreSigner) SignTx(tx *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
-	return kss.keystore.SignTxWithPassphrase(kss.account, kss.password, tx, chainID)
-}
-
-func (kss *keystoreSigner) GetAddress() common.Address {
-	return kss.account.Address
-}
-
-func (kss *keystoreSigner) GetPrivateKey() (*ecdsa.PrivateKey, error) {
-	return extractPrivateKey(kss.account.URL.Path, kss.password)
-}
-
-func (kss *keystoreSigner) ZeroPrivateKey(key *ecdsa.PrivateKey) {
-	b := key.D.Bits()
-	for i := range b {
-		b[i] = 0
-	}
-	// Force garbage collection to remove the key from memory
-	runtime.GC()
-}
-
-func extractPrivateKey(keystoreFile, passphrase string) (*ecdsa.PrivateKey, error) {
-	keyjson, err := os.ReadFile(keystoreFile)
-	if err != nil {
-		return nil, err
-	}
-
-	key, err := keystore.DecryptKey(keyjson, passphrase)
-	if err != nil {
-		return nil, err
-	}
-
-	// Overwrite the keyjson slice with zeros to wipe the sensitive data from memory.
-	// This is a security measure to reduce the risk of the encrypted key being extracted from memory.
-	for i := range keyjson {
-		keyjson[i] = 0
-	}
-
-	return key.PrivateKey, nil
 }

--- a/pkg/keysigner/keystoresigner.go
+++ b/pkg/keysigner/keystoresigner.go
@@ -1,0 +1,71 @@
+package keysigner
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"io"
+	"math/big"
+	"runtime"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type keystoreSigner struct {
+	keystore *keystore.KeyStore
+	password string
+	account  accounts.Account
+}
+
+func NewKeystoreSigner(wr io.Writer, path, password string) (*keystoreSigner, error) {
+	// lightscripts are using 4MB memory and taking approximately 100ms CPU time on a modern processor to decrypt
+	keystore := keystore.NewKeyStore(path, keystore.LightScryptN, keystore.LightScryptP)
+	ksAccounts := keystore.Accounts()
+
+	var account accounts.Account
+	if len(ksAccounts) == 0 {
+		var err error
+		account, err = keystore.NewAccount(password)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create account: %w", err)
+		}
+	} else {
+		account = ksAccounts[0]
+	}
+
+	fmt.Fprintf(wr, "Public address of the key: %s\n", account.Address.Hex())
+	fmt.Fprintf(wr, "Path of the secret key file: %s\n", account.URL.Path)
+
+	return &keystoreSigner{
+		keystore: keystore,
+		password: password,
+		account:  account,
+	}, nil
+}
+
+func (kss *keystoreSigner) SignHash(hash []byte) ([]byte, error) {
+	return kss.keystore.SignHashWithPassphrase(kss.account, kss.password, hash)
+}
+
+func (kss *keystoreSigner) SignTx(tx *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
+	return kss.keystore.SignTxWithPassphrase(kss.account, kss.password, tx, chainID)
+}
+
+func (kss *keystoreSigner) GetAddress() common.Address {
+	return kss.account.Address
+}
+
+func (kss *keystoreSigner) GetPrivateKey() (*ecdsa.PrivateKey, error) {
+	return extractPrivateKey(kss.account.URL.Path, kss.password)
+}
+
+func (kss *keystoreSigner) ZeroPrivateKey(key *ecdsa.PrivateKey) {
+	b := key.D.Bits()
+	for i := range b {
+		b[i] = 0
+	}
+	// Force garbage collection to remove the key from memory
+	runtime.GC()
+}

--- a/pkg/keysigner/privatekeysigner.go
+++ b/pkg/keysigner/privatekeysigner.go
@@ -1,0 +1,125 @@
+package keysigner
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type privateKeySigner struct {
+	privKey *ecdsa.PrivateKey
+}
+
+func NewPrivateKeySigner(wr io.Writer, path string) (*privateKeySigner, error) {
+	privKeyFile, err := resolveFilePath(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get private key file path: %w", err)
+	}
+
+	if err := createKeyIfNotExists(wr, privKeyFile); err != nil {
+		return nil, fmt.Errorf("failed to create private key: %w", err)
+	}
+
+	privKey, err := crypto.LoadECDSA(privKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load private key from file '%s': %w", privKeyFile, err)
+	}
+
+	return &privateKeySigner{
+		privKey: privKey,
+	}, nil
+}
+
+func (pks *privateKeySigner) SignHash(hash []byte) ([]byte, error) {
+	return crypto.Sign(hash, pks.privKey)
+}
+
+func (pks *privateKeySigner) SignTx(tx *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
+	return types.SignTx(tx, types.NewLondonSigner(chainID), pks.privKey)
+}
+
+func (pks *privateKeySigner) GetAddress() common.Address {
+	return crypto.PubkeyToAddress(pks.privKey.PublicKey)
+}
+
+func (pks *privateKeySigner) GetPrivateKey() (*ecdsa.PrivateKey, error) {
+	return pks.privKey, nil
+}
+
+// ZeroPrivateKey does nothing because the private key for PKS persists in memory
+// and should not be deleted.
+func (pks *privateKeySigner) ZeroPrivateKey(key *ecdsa.PrivateKey) {}
+
+func extractPrivateKey(keystoreFile, passphrase string) (*ecdsa.PrivateKey, error) {
+	keyjson, err := os.ReadFile(keystoreFile)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := keystore.DecryptKey(keyjson, passphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	// Overwrite the keyjson slice with zeros to wipe the sensitive data from memory.
+	// This is a security measure to reduce the risk of the encrypted key being extracted from memory.
+	for i := range keyjson {
+		keyjson[i] = 0
+	}
+
+	return key.PrivateKey, nil
+}
+
+func createKeyIfNotExists(wr io.Writer, path string) error {
+	if _, err := os.Stat(path); err == nil {
+		fmt.Fprintln(wr, "using existing private key:", path)
+		return nil
+	}
+
+	fmt.Fprintln(wr, "creating new private key:", path)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		return err
+	}
+
+	if err := crypto.SaveECDSA(path, key); err != nil {
+		return err
+	}
+
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	fmt.Fprintln(wr, "private key saved to file:", path)
+	fmt.Fprintln(wr, "wallet address:", addr.Hex())
+
+	return nil
+}
+
+func resolveFilePath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+
+	if strings.HasPrefix(path, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+
+		return filepath.Join(home, path[1:]), nil
+	}
+
+	return path, nil
+}


### PR DESCRIPTION
* moved key signer init logic from `main.go` to `keysigner` package
* split up `keysigner.go` into three files: `keysigner.go`, `keystoresigner.go` and `privatesigner.go`